### PR TITLE
Support for region (multi-site Openstack) and idp_protocol

### DIFF
--- a/cloud_info_provider/providers/openstack.py
+++ b/cloud_info_provider/providers/openstack.py
@@ -343,7 +343,8 @@ class OpenStackProvider(providers.BaseProvider):
         img_sch = defaults.get('image_schema', 'os')
         URI = 'http://schemas.openstack.org/template/'
 
-        for image in self.glance.images.list(detailed=True):
+        for image in self.glance.images.list(detailed=True,
+                                             filters={'status': 'active'}):
             img_id = image.get("id")
 
             aux_img = copy.deepcopy(template)

--- a/cloud_info_provider/providers/openstack.py
+++ b/cloud_info_provider/providers/openstack.py
@@ -46,7 +46,7 @@ except ImportError:
 def _rescope(f):
     @functools.wraps(f)
     def inner(self, auth=None, **kwargs):
-        self._rescope_project(auth['project_id'])
+        self._rescope_project(auth['project_id'], auth.get('region_name'))
         return f(self, **kwargs)
     return inner
 
@@ -135,7 +135,7 @@ class OpenStackProvider(providers.BaseProvider):
             share['project'] = share.get('auth', {}).get('project_id')
         return shares
 
-    def _rescope_project(self, project_id):
+    def _rescope_project(self, project_id, region_name=None):
         '''Switch to new OS project whenever there is a change.
 
            It updates every OpenStack client used in case of new project.
@@ -144,6 +144,7 @@ class OpenStackProvider(providers.BaseProvider):
             self.opts.os_project_id = project_id
             # make sure that it also works for v2voms
             self.opts.os_tenant_id = project_id
+            self.opts.os_region_name = region_name
             self.auth_plugin = loading.load_auth_from_argparse_arguments(
                 self.opts
             )
@@ -157,8 +158,8 @@ class OpenStackProvider(providers.BaseProvider):
                 msg = "Could not authorize user in project '%s'" % project_id
                 raise exceptions.OpenStackProviderException(msg)
             # make sure the clients know about the change
-            self.nova = novaclient.client.Client(2, session=self.session)
-            self.glance = glanceclient.Client('2', session=self.session)
+            self.nova = novaclient.client.Client(2, session=self.session, region_name=region_name)
+            self.glance = glanceclient.Client('2', session=self.session, region_name=region_name)
 
     @staticmethod
     def _get_endpoint_versions(endpoint_url):
@@ -199,7 +200,7 @@ class OpenStackProvider(providers.BaseProvider):
         ret['compute_service_name'] = self.auth_plugin.auth_url
         catalog = self.auth_plugin.get_access(self.session).service_catalog
         epts = catalog.get_endpoints(service_type=self.service_type,
-                                     interface="public")
+                                     interface="public", region_name = defaults.get('compute_region'))
         for ept in epts.get(self.service_type, []):
             e_id = ept['id']
             # URL is in different places depending of Keystone version
@@ -238,6 +239,7 @@ class OpenStackProvider(providers.BaseProvider):
                                           self.insecure))
             e.update(self._get_extra_endpoint_info(e_url))
             ret['endpoints'][e_id_url] = e
+
         return ret
 
     @_rescope
@@ -341,8 +343,7 @@ class OpenStackProvider(providers.BaseProvider):
         img_sch = defaults.get('image_schema', 'os')
         URI = 'http://schemas.openstack.org/template/'
 
-        for image in self.glance.images.list(detailed=True,
-                                             filters={'status': 'active'}):
+        for image in self.glance.images.list(detailed=True):
             img_id = image.get("id")
 
             aux_img = copy.deepcopy(template)
@@ -414,7 +415,7 @@ class OpenStackProvider(providers.BaseProvider):
             ret = instance_template.copy()
             ret.update({
                 'instance_name': instance.name,
-                'instance_image_id': instance.image['id'],
+                'instance_image_id': instance.image['id'] if 'id' in instance.image else '',
                 'instance_template_id': instance.flavor['id'],
                 'instance_status': instance.status,
             })

--- a/cloud_info_provider/providers/static.py
+++ b/cloud_info_provider/providers/static.py
@@ -182,9 +182,9 @@ class StaticProvider(providers.BaseProvider):
                                      'network_virt_type', 'cpu_virt_type',
                                      'failover', 'live_migration',
                                      'vm_backup_restore',
-                                     'service_name',
+                                     'service_name', 'region',
                                      'public_ip_assignable',
-                                     'iam_enabled')
+                                     'iam_enabled', 'idp_protocol')
         endpoint_fields = endp_f or ('production_level', 'api_type',
                                      'api_version',
                                      'api_endpoint_technology',
@@ -204,7 +204,7 @@ class StaticProvider(providers.BaseProvider):
         global_fields = ('service_production_level', 'total_storage',
                          'capabilities', 'middleware',
                          'middleware_version', 'middleware_developer',
-                         'service_name', 'iam_enabled')
+                         'service_name', 'iam_enabled', 'idp_protocol')
         endpoint_fields = ('production_level', 'api_type', 'api_version',
                            'api_endpoint_technology',
                            'api_authn_method')
@@ -277,6 +277,8 @@ class StaticProvider(providers.BaseProvider):
             'live_migration': False,
             'vm_backup_restore': False,
             'total_accelerators': 0,
+            'region': '',
+            'idp_protocol': 'oidc'
         }
         return self._populate_default_values(
             self._get_defaults_from_yaml('compute',

--- a/etc/templates/compute.cmdb.json
+++ b/etc/templates/compute.cmdb.json
@@ -18,8 +18,10 @@
     provider_id = static_compute_info['site_name']
     service_id = static_compute_info['compute_service_name']
     is_public = static_compute_info['site_is_public']
+    region = static_compute_info['compute_region']
     iam_enabled = static_compute_info['compute_iam_enabled']
-	
+    idp_protocol = static_compute_info['compute_idp_protocol']
+
     from six.moves import urllib
     urlparse_obj = urllib.parse.urlparse(service_id)
     host_name = service_id
@@ -45,8 +47,10 @@
         "data": {
             "provider_id": "${provider_id}",
             "id": "${service_id}",
-            "is_public_service": ${'true' if is_public else 'false'},
+            "region": "${region}",
             "iam_enabled": ${'true' if iam_enabled else 'false'},
+            "idp_protocol": "${idp_protocol}",
+            "is_public_service": ${'true' if is_public else 'false'},
             ${render_string('hostname', host_name)}
             ${render_string('service_type', goc_service_type)}
             ${render_string('sitename', static_compute_info['site_name'])}


### PR DESCRIPTION
# Summary 
This PR adds new features in the openstack provider for:
- usage in multi-site Openstack cloud: you can specify the region to query nova/glance endpoints
- new fields read from the static configuration: 
  * region - openstack region name
  * idp_protocol - name of the protocol configured in keystone for oidc authentication (e.g. oidc, openid) 